### PR TITLE
Add Not Human Search for MCP verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Software tools that implement AI for security applications.
 - [promptfoo](https://github.com/promptfoo/promptfoo) - Open-source LLM red teaming tool for finding and fixing vulnerabilities. 100+ attack types, 250k+ users.
 - [Snaike-MLFlow](https://github.com/protectai/Snaike-MLflow) - MLflow-focused red team toolsuite for attacking ML pipelines and infrastructure.
 - [MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) - Security scanning tool specifically designed for Model Context Protocol servers.
+- [Not Human Search](https://nothumansearch.ai) - MCP server and API that live-verifies MCP endpoints and scores agent-readiness signals, useful for checking whether external tools are real before security agents call them.
 
 ### Learning Environments
 


### PR DESCRIPTION
Adds Not Human Search under Security Testing next to MCP-Scan.

Fit:
- It live-verifies MCP endpoints and scores agent-readiness signals.
- That helps security agents avoid trusting fake or broken external MCP/tool endpoints.

Validation:
- nothumansearch.ai returned HTTP 200.
- The MCP endpoint answered a real tools/list JSON-RPC request.