### PR TITLE
Add APort to security agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ AI systems designed to perform security-related tasks with varying degrees of au
 
 - [HackingBuddyGPT](https://github.com/ipa-lab/hackingBuddyGPT) - Autonomous pentesting agent with corresponding benchmark dataset for standardized evaluation.
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows with automated detection.
+- [APort](https://aport.io) - Agent identity verification and runtime policy enforcement for autonomous AI workflows.
 - [Fraim](https://github.com/fraim-dev/fraim) A flexible framework for security teams to build and deploy AI-powered workflows.
 
 ### Red Team Agents


### PR DESCRIPTION
## Summary
- Add APort to the Autonomous Agents section.

## Why this fits
APort provides agent identity verification and runtime policy enforcement for autonomous AI workflows, which complements the security-agent resources in this list.

## Verification
- `git diff --check -- README.md`
- `rg -n "APort|aport.io" README.md`
- `curl.exe -I -L --max-time 20 https://aport.io`

Related bounty: https://github.com/aporthq/aport-integrations/issues/19

Payout if selected for the bounty: PayPal https://paypal.me/Jeremytsangchina or USDT TRC20 TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y