### PR TITLE
Add Armorer Guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Software tools that implement AI for security applications.
 - [promptfoo](https://github.com/promptfoo/promptfoo) - Open-source LLM red teaming tool for finding and fixing vulnerabilities. 100+ attack types, 250k+ users.
 - [Snaike-MLFlow](https://github.com/protectai/Snaike-MLflow) - MLflow-focused red team toolsuite for attacking ML pipelines and infrastructure.
 - [MCP-Scan](https://github.com/invariantlabs-ai/mcp-scan) - Security scanning tool specifically designed for Model Context Protocol servers.
+- [Armorer Guard](https://github.com/ArmorerLabs/Armorer-Guard) - Local Rust scanner and MCP proxy for AI-agent prompt injection, credential leakage, exfiltration, and risky tool-call arguments.
 
 ### Learning Environments
 


### PR DESCRIPTION
Adds Armorer Guard to Security Testing.\n\nDisclosure: I maintain Armorer Guard at Armorer Labs. It is a MIT-licensed local Rust scanner and MCP proxy for AI-agent prompt injection, credential leakage, exfiltration, and risky tool-call arguments. I placed it in Security Testing because it is intended for inline agent/MCP security checks and local red-team/security validation workflows.\n\nThanks for maintaining this AI-for-security resource.